### PR TITLE
Add SSL support, port definitions, and support of the other destination cluster.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+vendored/
 env/
 build/
 develop-eggs/

--- a/README.md
+++ b/README.md
@@ -34,46 +34,80 @@ I was initially messing around with the API, and thought it'd be nice to create 
 
 To use the tool you'll need to install it's dependencies.
 
-	pip install -r requirements.txt
+	pip install -t vendored/ -r requirements.txt
 
 Currently I've only tested it with Python 2.X
 
 
 ## Usage
 
-	usage: es-tool.py [-h] [-r REINDEX] [-n NEW_INDEX_NAME] [-d DELETE_INDEX] -e
-	                  ENDPOINT
+    usage: es-tool.py [-h] [-r REINDEX] [-n NEW_INDEX_NAME] [-d DELETE_INDEX]
+                      [-S SOURCE] [-e ENDPOINT] [-D DESTINATION] [-ps PORT_SOURCE]
+                      [-pd PORT_DESTINATION] [-ls SSL_SOURCE]
+                      [-ld SSL_DESTINATION]
 
-	Elasticsearch management
+    Elasticsearch management
 
-	optional arguments:
-	  -h, --help            show this help message and exit
-	  -r REINDEX, --reindex REINDEX
-	                        Reindex all documents in specified index and append
-	                        with "-reindex", if --new_index_name options has not
-	                        been specified
-	  -n NEW_INDEX_NAME, --new_index_name NEW_INDEX_NAME
-	                        Name for new index
-	  -d DELETE_INDEX, --delete_index DELETE_INDEX
-	                        Specify which index to delete
-	  -e ENDPOINT, --endpoint ENDPOINT
-	                        Specify Elasticsearch host
+    optional arguments:
+      -h, --help            show this help message and exit
+      -r REINDEX, --reindex REINDEX
+                            Reindex all documents in specified index and append
+                            with "-reindex", if --new_index_name options has not
+                            been specified
+      -n NEW_INDEX_NAME, --new_index_name NEW_INDEX_NAME
+                            Name for new index
+      -d DELETE_INDEX, --delete_index DELETE_INDEX
+                            Specify which index to delete from source ES
+      -S SOURCE, --source SOURCE
+                            Specify Elasticsearch host from which the data will be
+                            downloaded
+      -e ENDPOINT, --endpoint ENDPOINT
+                            Alias for --source for backward compatibility
+      -D DESTINATION, --destination DESTINATION
+                            Specify Elasticsearch host in which the data will be
+                            uploaded. If not specified, the --source connection
+                            will be used as destination.
+      -ps PORT_SOURCE, --port_source PORT_SOURCE
+                            Specify port for the source Elasticsearch (9200 by
+                            default, for AWS ES it can be 80 or 443).
+      -pd PORT_DESTINATION, --port_destination PORT_DESTINATION
+                            Specify port for the destination Elasticsearch (9200
+                            by default, for AWS ES it can be 80 or 443).
+      -ls SSL_SOURCE, --ssl_source SSL_SOURCE
+                            Use SSL (https) connection for the source
+                            ElasticSearch.
+      -ld SSL_DESTINATION, --ssl_destination SSL_DESTINATION
+                            Use SSL (https) connection.
 
 
-### Example
+### Reindex inside one cluster
 
 If you wanted to reindex an index you can do this:
 
-	./es-tool.py --elasticsearch http://elasticsearch --reindex name-of-index --new_index_name name-of-new-index
+	./es-tool.py \
+        --source elasticsearch-host \
+        --reindex name-of-index \
+        --new_index_name name-of-new-index \
+        --ssl_source true \
+        --port_source 443
 
 The tool will reindex the indices on the same cluster and append "-reindex" to the end e.g. *"name-of-index-reindex"*
 
+### Reindex from one cluster to another one
+
+    ./es-tool.py \
+        --source elasticsearch-host-1 \
+        --destination elasticsearch-host-2 \
+        --reindex name-of-index \
+        --new_index_name name-of-new-index \
+        --ssl_source true \
+        --port_source 443 \
+        --ssl_destination true \
+        --port_destination 443
 
 ## To do
 
 * List indexes
 * Dry-run
-* Ability to specify source and destination hosts
-* Fix SSL Whining
 * Improve logging/messages
 * **Refactor into a module fashion like my hubot-scripts implementation**

--- a/es-tool.py
+++ b/es-tool.py
@@ -1,36 +1,83 @@
 #!/usr/bin/env python
 
-from elasticsearch import Elasticsearch
-from elasticsearch import helpers
-import argparse
 import sys
+import os
+import argparse
 
+current_path = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(current_path, "vendored"))
+
+from elasticsearch import Elasticsearch, RequestsHttpConnection, helpers
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Elasticsearch management')
     parser.add_argument('-r', '--reindex', action='store', help='Reindex all documents in specified index and append with "-reindex", if --new_index_name options has not been specified')
     parser.add_argument('-n', '--new_index_name', action='store', help='Name for new index')
-    parser.add_argument('-d', '--delete_index', action='store', help='Specify which index to delete')
-    parser.add_argument('-e', '--endpoint', action='store', help='Specify Elasticsearch host', required=True)
+    parser.add_argument('-d', '--delete_index', action='store', help='Specify which index to delete from source ES')
+    parser.add_argument('-S', '--source', action='store', help='Specify Elasticsearch host from which the data will be downloaded', required=False)
+    parser.add_argument('-e', '--endpoint', action='store', help='Alias for --source for backward compatibility', required=False)
+    parser.add_argument('-D', '--destination', action='store', help='Specify Elasticsearch host in which the data will be uploaded. If not specified, the --source connection will be used as destination.', required=False)
+    parser.add_argument('-ps', '--port_source', action='store', help='Specify port for the source Elasticsearch (9200 by default, for AWS ES it can be 80 or 443).', required=False)
+    parser.add_argument('-pd', '--port_destination', action='store', help='Specify port for the destination Elasticsearch (9200 by default, for AWS ES it can be 80 or 443).', required=False)
+    parser.add_argument('-ls', '--ssl_source', action='store', help='Use SSL (https) connection for the source ElasticSearch.', required=False, default=False)
+    parser.add_argument('-ld', '--ssl_destination', action='store', help='Use SSL (https) connection.', required=False, default=False)
     args = parser.parse_args()
+
     return args
 
-
-def es():
-    # Creates the connection with Elasticsearch
+def esSrc():
+    """
+    Creates the connection with Elasticsearch from which the data will be downloaded
+    """
     args = parse_args()
 
-    host = args.endpoint
-    conn = Elasticsearch(host)
+    if not args.endpoint:
+        host = args.source
+    else:
+        # backward compatibility
+        host = args.endpoint
+    if not host:
+        raise Exception('error: argument -S/--source is required')
+
+    conn = Elasticsearch(
+        host,
+        use_ssl=args.ssl_source in ['true', '1', 't', 'y', 'yes'],
+        verify_certs=True,
+        connection_class=RequestsHttpConnection,
+        port=int(args.port_source)
+    )
 
     return conn
 
+def esDest():
+    """
+    Creates the connection with Elasticsearch in which the data will be uploaded
+    """
 
-def delete():
-    # To delete an index specified
     args = parse_args()
 
-    conn = es()
+    if not args.destination:
+
+        return None
+    else:
+        host = args.destination
+        conn = Elasticsearch(
+            host,
+            use_ssl=args.ssl_destination in ['true', '1', 't', 'y', 'yes'],
+            verify_certs=True,
+            connection_class=RequestsHttpConnection,
+            port=int(args.port_source)
+        )
+
+        return conn
+
+def delete():
+    """
+    To delete an index specified
+    """
+    args = parse_args()
+
+    conn = esSrc()
     index_to_remove = args.delete_index
 
     conn.indices.delete(index=index_to_remove)
@@ -38,7 +85,10 @@ def delete():
 
 
 def reindex():
-    # To reindex a specified index and appends the new index with "-reindex" if the --new_index_name options has not been specified
+    """
+    To reindex a specified index and appends the new index with "-reindex"
+    if the --new_index_name options has not been specified
+    """
     args = parse_args()
 
     src_index_name = args.reindex
@@ -48,7 +98,7 @@ def reindex():
     else:
         des_index_name = src_index_name + "-reindex"
 
-    helpers.reindex(es(), src_index_name, des_index_name)
+    helpers.reindex(esSrc(), src_index_name, des_index_name, None, esDest())
     print(src_index_name + " has been reindexed to " + des_index_name)
 
 
@@ -56,7 +106,10 @@ def main():
     args = parse_args()
 
     if args.delete_index:
-        delete()
+        if raw_input('Are you sure to delete index "' + args.delete_index + '"? This operation cannot be reversed. (yes/no)').lower() in ('y', 'yes'):
+            delete()
+        else:
+            print('Canceled')
     elif args.reindex:
         reindex()
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-elasticsearch==2.4.0
+elasticsearch>=5.0.0,<6.0.0
 urllib3==1.18
+requests>=2.8.1


### PR DESCRIPTION


Store requirements inside local `vendored` directory.
Prompt before deleting index.
Replace endpoint argument with `source`.
Add `destination` argument.
Add `port_source` and `port_destination` arguments.
Add `ssl_source` and `ssl_destination` arguments.
Update Readme.